### PR TITLE
[Config] sort tags by count and alphabetically in tag data generation

### DIFF
--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -76,7 +76,16 @@ async function createTagCount(allBlogs) {
       })
     }
   })
-  const formatted = await prettier.format(JSON.stringify(tagCount, null, 2), { parser: 'json' })
+  // Sort tags by count (descending) and then alphabetically (ascending)
+  const sortedTagCount = Object.fromEntries(
+    Object.entries(tagCount).sort(([tagA, countA], [tagB, countB]) => {
+      if (countB !== countA) {
+        return countB - countA
+      }
+      return tagA.localeCompare(tagB)
+    })
+  )
+  const formatted = await prettier.format(JSON.stringify(sortedTagCount, null, 2), { parser: 'json' })
   writeFileSync('./app/tag-data.json', formatted)
 }
 


### PR DESCRIPTION
This PR make the `tags.json` sort the tags in ascending order, rather than random. This fix annoyances where the tags.json changes and pushed, and it become inconsistent every branches and need to resolve merge conflict.